### PR TITLE
Add `FETCH` connection mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Fetch:
 ```go
 // Retrieve up to 20 records starting from offset 100, in reverse direction (-1),
 // with query `brand.name == "Chevrolet"` and with a 5 seconds timeout.
-// Returns a slice of bytes.
-data, err := Fetch("localhost", "9099", 100, -1 `brand.name == "Chevrolet"`, 20, 5*time.Second)
+// Returns a slice of records and the latest meta state.
+data, meta, err := Fetch("localhost", "9099", 100, -1 `brand.name == "Chevrolet"`, 20, 5*time.Second)
 if err != nil {
     panic(err)
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ The server also streams the query progress through `/metadata` command to the cl
 
 - **Single mode** is a short lasting TCP connection that returns a single record from the database based on the provided index value.
 
+- **Fetch mode** is a short lasting TCP connection mode for fetching N number of records from the database,
+starting from a certain offset, supporting both directions.
+
 - **Validate mode** checks the query against syntax errors. Returns the error if it's syntactically invalid otherwise returns `OK`.
 
 - **Macro mode** let's you define a macro for the query language like `http~proto.name == "http"`.
@@ -98,6 +101,18 @@ Single:
 ```go
 // Retrieve the record with ID equals to 42
 data, err := Single("localhost", "9099", 42)
+if err != nil {
+    panic(err)
+}
+```
+
+Fetch:
+
+```go
+// Retrieve up to 20 records starting from offset 100, in reverse direction (-1),
+// with query `brand.name == "Chevrolet"` and with a 5 seconds timeout.
+// Returns a slice of bytes.
+data, err := Fetch("localhost", "9099", 100, -1 `brand.name == "Chevrolet"`, 20, 5*time.Second)
 if err != nil {
     panic(err)
 }

--- a/client/go/client.go
+++ b/client/go/client.go
@@ -31,6 +31,7 @@ const (
 	CMD_INSERT   string = "/insert"
 	CMD_QUERY    string = "/query"
 	CMD_SINGLE   string = "/single"
+	CMD_FETCH    string = "/fetch"
 	CMD_VALIDATE string = "/validate"
 	CMD_MACRO    string = "/macro"
 	CMD_LIMIT    string = "/limit"
@@ -110,6 +111,43 @@ func Single(host string, port string, id int) (data []byte, err error) {
 	data = <-ret
 	c.Close()
 	return
+}
+
+func Fetch(host string, port string, leftOff int, direction int, query string, limit int, timeout time.Duration) (data [][]byte, err error) {
+	var c *Connection
+	c, err = NewConnection(host, port)
+	if err != nil {
+		return
+	}
+
+	ret := make(chan []byte)
+
+	var wg sync.WaitGroup
+	go readConnection(&wg, c, ret, nil)
+	wg.Add(1)
+
+	c.SendText(CMD_FETCH)
+	c.SendText(fmt.Sprintf("%d", leftOff))
+	c.SendText(fmt.Sprintf("%d", direction))
+	c.SendText(fmt.Sprintf("%s", query))
+	c.SendText(fmt.Sprintf("%d", limit))
+
+	afterCh := time.After(timeout)
+	counter := 0
+	for {
+		select {
+		case record := <-ret:
+			data = append(data, record)
+			counter++
+			if counter >= limit {
+				c.Close()
+				return
+			}
+		case <-afterCh:
+			c.Close()
+			return
+		}
+	}
 }
 
 // Validate validates the given query against syntax errors by passing the query

--- a/client/go/client_test.go
+++ b/client/go/client_test.go
@@ -138,6 +138,18 @@ func TestQuery(t *testing.T) {
 	}
 }
 
+func TestFetch(t *testing.T) {
+	data, err := Fetch(HOST, PORT, 100, -1, `chevy`, 20, 5*time.Second)
+	assert.Nil(t, err)
+
+	i := 0
+	for id := 100; id > 80; id-- {
+		expected := fmt.Sprintf(`{"brand":{"name":"Chevrolet"},"id":%d,"model":"Camaro","year":2021}`, id)
+		assert.Equal(t, expected, string(data[i]))
+		i++
+	}
+}
+
 func TestTCPConnectionLeak(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		err := Validate(HOST, PORT, `brand.name == "Chevrolet"`)

--- a/client/go/client_test.go
+++ b/client/go/client_test.go
@@ -139,8 +139,10 @@ func TestQuery(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	data, err := Fetch(HOST, PORT, 100, -1, `chevy`, 20, 5*time.Second)
+	data, meta, err := Fetch(HOST, PORT, 100, -1, `chevy`, 20, 5*time.Second)
 	assert.Nil(t, err)
+
+	assert.Equal(t, `{"current":81,"total":15000,"numberOfWritten":19,"leftOff":81}`, string(meta))
 
 	i := 0
 	for id := 100; id > 80; id-- {

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -69,6 +70,7 @@ const (
 	INSERT
 	QUERY
 	SINGLE
+	FETCH
 	VALIDATE
 	MACRO
 	LIMIT
@@ -81,6 +83,7 @@ const (
 	CMD_INSERT   string = "/insert"
 	CMD_QUERY    string = "/query"
 	CMD_SINGLE   string = "/single"
+	CMD_FETCH    string = "/fetch"
 	CMD_VALIDATE string = "/validate"
 	CMD_MACRO    string = "/macro"
 	CMD_LIMIT    string = "/limit"
@@ -409,6 +412,9 @@ func handleConnection(conn net.Conn) {
 	// Set connection mode to NONE
 	var mode ConnectionMode = NONE
 
+	// Arguments for the FETCH command (leftOff, direction, query, limit)
+	var fetchArgs []string
+
 	for {
 		// Scan the input
 		ok := scanner.Scan()
@@ -444,6 +450,13 @@ func handleConnection(conn net.Conn) {
 			streamRecords(conn, data)
 		case SINGLE:
 			retrieveSingle(conn, data)
+		case FETCH:
+			if len(fetchArgs) < 4 {
+				fetchArgs = append(fetchArgs, string(data))
+			}
+			if len(fetchArgs) == 4 {
+				fetch(conn, fetchArgs)
+			}
 		case VALIDATE:
 			validateQuery(conn, data)
 		case MACRO:
@@ -485,6 +498,9 @@ func handleMessage(message string, conn net.Conn) (mode ConnectionMode, data []b
 
 		case message == CMD_SINGLE:
 			mode = SINGLE
+
+		case message == CMD_FETCH:
+			mode = FETCH
 
 		case strings.HasPrefix(message, CMD_VALIDATE):
 			mode = VALIDATE
@@ -644,20 +660,14 @@ func watchPartitions() (err error) {
 	return
 }
 
-// streamRecords is an infinite loop that only called in case of QUERY TCP connection mode.
-// It expands marcros, parses the given query, does compile-time evaluations with Precompute() call
-// and filters out the records according to query.
-// It starts from the very beginning of the first living database partition.
-// Means that either the current partition or the partition before that.
-func streamRecords(conn net.Conn, data []byte) (err error) {
-	query := string(data)
-
+// prepareQuery get the query as an argument and handles expansion, parsing and compile-time evaluations.
+func prepareQuery(conn net.Conn, query string) (expr *Expression, limit uint64, rlimit uint64, leftOff int64, err error) {
 	// Expand all macros in the query, if there are any.
 	query, err = expandMacros(query)
 	check(err)
 
 	// Parse the query.
-	expr, err := Parse(query)
+	expr, err = Parse(query)
 	if err != nil {
 		log.Printf("Syntax error: %v\n", err)
 		conn.Close()
@@ -666,8 +676,19 @@ func streamRecords(conn net.Conn, data []byte) (err error) {
 	// leftOff is the state to track the last offset's index in cs.offsets
 	// default value of leftOff is 0. leftOff(..) helper overrides it.
 	// can be -1 also, means that it's last record.
-	limit, rlimit, leftOff, err := Precompute(expr)
+	limit, rlimit, leftOff, err = Precompute(expr)
 	check(err)
+
+	return
+}
+
+// streamRecords is an infinite loop that only called in case of QUERY TCP connection mode.
+// It expands marcros, parses the given query, does compile-time evaluations with Precompute() call
+// and filters out the records according to query.
+// It starts from the very beginning of the first living database partition.
+// Means that either the current partition or the partition before that.
+func streamRecords(conn net.Conn, data []byte) (err error) {
+	expr, limit, rlimit, leftOff, err := prepareQuery(conn, string(data))
 
 	// If leftOff value is -1 then set it to last offset
 	if leftOff < 0 {
@@ -921,6 +942,134 @@ func retrieveSingle(conn net.Conn, data []byte) (err error) {
 	f.Close()
 	conn.Write([]byte(fmt.Sprintf("%s\n", b)))
 	return
+}
+
+// Reverses a slice. panics if s is not a slice
+func ReverseSlice(s interface{}) {
+	size := reflect.ValueOf(s).Len()
+	swap := reflect.Swapper(s)
+	for i, j := 0, size-1; i < j; i, j = i+1, j-1 {
+		swap(i, j)
+	}
+}
+
+// fetch defines a macro that will be expanded for each individual query.
+func fetch(conn net.Conn, args []string) {
+	// Parse the arguments
+	leftOff, err := strconv.Atoi(args[0])
+	if err != nil {
+		conn.Write([]byte(fmt.Sprintf("Error: While converting the index to integer: %s\n", err.Error())))
+		return
+	}
+	direction, err := strconv.Atoi(args[1])
+	if err != nil {
+		conn.Write([]byte(fmt.Sprintf("Error: While converting the direction to integer: %s\n", err.Error())))
+		return
+	}
+	query := args[2]
+	limit, err := strconv.Atoi(args[3])
+	if err != nil {
+		conn.Write([]byte(fmt.Sprintf("Error: While converting the limit to integer: %s\n", err.Error())))
+		return
+	}
+
+	expr, _, _, _, err := prepareQuery(conn, query)
+
+	// Number of written records to the TCP connection.
+	var numberOfWritten uint64 = 0
+
+	// f is the current partition we're reading the data from.
+	var f *os.File
+
+	err = connCheck(conn)
+	if err != nil {
+		// Connection was closed by the peer, close the current partition.
+		if f != nil {
+			f.Close()
+		}
+		return
+	}
+
+	// Safely access the next part of offsets and partition references.
+	var subOffsets []int64
+	var subPartitionRefs []int64
+	cs.RLock()
+	if direction < 0 {
+		subOffsets = cs.offsets[:leftOff+1]
+		subPartitionRefs = cs.partitionRefs[:leftOff+1]
+	} else {
+		subOffsets = cs.offsets[leftOff:]
+		subPartitionRefs = cs.partitionRefs[leftOff:]
+	}
+	cs.RUnlock()
+
+	if direction < 0 {
+		ReverseSlice(subOffsets)
+	}
+
+	// Iterate through the next part of the offsets
+	for i, offset := range subOffsets {
+		if int(numberOfWritten) >= limit {
+			return
+		}
+
+		if direction < 0 {
+			leftOff--
+		} else {
+			leftOff++
+		}
+
+		// Safely access the *os.File pointer that the current offset refers to.
+		var partitionRef int64
+		cs.RLock()
+		partitionRef = subPartitionRefs[i]
+		fRef := cs.partitions[partitionRef]
+		cs.RUnlock()
+
+		// f == nil means we didn't open any partition yet.
+		// fRef.Name() != f.Name() means we're switching to the next partition.
+		if f == nil || fRef.Name() != f.Name() {
+			if f != nil && fRef.Name() != f.Name() {
+				// We're switching to the next partition, close the current partition.
+				f.Close()
+			}
+
+			// Open the partition that the current offset refers to.
+			f, err = os.Open(fRef.Name())
+
+			// If the file cannot be opened, pass.
+			if err != nil {
+				continue
+			}
+		}
+
+		// Seek to the offset
+		f.Seek(offset, io.SeekStart)
+
+		// Read the record into b
+		var b []byte
+		b, _, err = readRecord(f, offset)
+
+		// Even if it's EOF, continue.
+		// Because a later offset might point to a previous region of the file.
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			continue
+		}
+
+		// Evaluate the current record against the given query.
+		truth, err := Eval(expr, string(b))
+		check(err)
+
+		// Write the record into TCP connection if it passes the query.
+		if truth {
+			_, err := conn.Write([]byte(fmt.Sprintf("%s\n", b)))
+			if err != nil {
+				log.Printf("Write error: %v\n", err)
+				break
+			}
+			numberOfWritten++
+		}
+	}
 }
 
 // validateQuery tries to parse the given query and checks if there are

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -954,13 +953,12 @@ func retrieveSingle(conn net.Conn, data []byte) (err error) {
 	return
 }
 
-// Reverses a slice. panics if s is not a slice
-func ReverseSlice(s interface{}) {
-	size := reflect.ValueOf(s).Len()
-	swap := reflect.Swapper(s)
-	for i, j := 0, size-1; i < j; i, j = i+1, j-1 {
-		swap(i, j)
+// Reverses an int64 slice.
+func ReverseSlice(arr []int64) (newArr []int64) {
+	for i := len(arr) - 1; i >= 0; i-- {
+		newArr = append(newArr, arr[i])
 	}
+	return newArr
 }
 
 // fetch defines a macro that will be expanded for each individual query.
@@ -1040,7 +1038,7 @@ func fetch(conn net.Conn, args []string) {
 	})
 
 	if direction < 0 {
-		ReverseSlice(subOffsets)
+		subOffsets = ReverseSlice(subOffsets)
 	}
 
 	// Iterate through the next part of the offsets


### PR DESCRIPTION
### Description

`FETCH` is a short lasting TCP connection mode for fetching N number of records from the database,
starting from a certain offset, supporting both directions.

### Related Issue

No related issues.

### Motivation and Context

[Mizu](https://github.com/up9inc/mizu) requires fetching to implement paging mode.

### How Has This Been Tested

Tested through unit tests.

### Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
