### PR TITLE
Upgrade the Alpine base image from version `3.13.5` to `3.15`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ COPY server server
 COPY Makefile .
 RUN make build GOOS=linux GOARCH=amd64
 
-FROM alpine:3.13.5
+FROM alpine:3.15
 COPY --from=builder ["/tmp/build/basenine_linux_amd64", "./basenine"]
 ENTRYPOINT "./basenine"


### PR DESCRIPTION
Fixes a bunch of vulnerabilities sourced from `bustbox:1.32.1-r6` base in the `Dockerfile`.